### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
Weil man keinen kompilierten Bytecode hochlädt!
Siehe 1954723890fefb2ae7d70bc42185cb9e15cbefc5, 3ed6c987f1940de116c2d16a48c1f7a014c0274b, 6543e1c6e6d5af3346f5ebcbb3783e2e56ff3bd8