### PR TITLE
HP logic out of Entity, into MortalBeing

### DIFF
--- a/core/src/com/infolk/game/combat/DavyCrockett.java
+++ b/core/src/com/infolk/game/combat/DavyCrockett.java
@@ -9,7 +9,7 @@ import com.badlogic.gdx.math.Vector2;
 
 public class DavyCrockett extends Entity {
     public DavyCrockett() {
-        super("Davy Crockett Nuclear Device", 10, new Sprite(new Texture(Gdx.files.internal("sprites/davycrockett.png"))));
+        super("Davy Crockett Nuclear Device", new Sprite(new Texture(Gdx.files.internal("sprites/davycrockett.png"))));
 
         setSpeed(250);
         setDirection(new Vector2(0, 1));

--- a/core/src/com/infolk/game/combat/Enemy.java
+++ b/core/src/com/infolk/game/combat/Enemy.java
@@ -3,7 +3,7 @@ package com.infolk.game.combat;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 
-public abstract class Enemy extends Entity {
+public abstract class Enemy extends NPC {
 
   private boolean isDead;
   private boolean isAttackable;
@@ -22,7 +22,7 @@ public abstract class Enemy extends Entity {
     }
     
     Vector2 richtung = vectorTo(player); // Richtungsvektor zwischen Player und Gegner
-    
+
     float x = 0;
     float y = 0;
 

--- a/core/src/com/infolk/game/combat/Entity.java
+++ b/core/src/com/infolk/game/combat/Entity.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
-import com.infolk.game.screens.components.HealthBar;
 
 public abstract class Entity {
     private Vector2 direction;
@@ -14,44 +13,26 @@ public abstract class Entity {
     private Sprite sprite;
 
     private String name;
-    private int hp;
 
     private Rectangle hitbox;
 
-    private HealthBar bar;
-    private float barWidth, barHeight;
-    public boolean displayBar = true;
-
-    protected Entity(String name, int hp, Sprite sprite) {
+    protected Entity(String name, Sprite sprite) {
         this.name = name;
-        this.hp = hp;
 
         // Initialize vector with 0, 0
         direction = new Vector2(0, 0);
         speed = 100;
 
         setSprite(sprite);
-        barWidth = sprite.getWidth();
-        barHeight = barWidth / 5;
 
         hitbox = new Rectangle();
         adjustHitbox();
-
-        bar = new HealthBar(getBarX(), getBarY(), barWidth, barHeight, hp, hp);
     }
 
-    protected Entity(String name, int hp, Sprite sprite, float x, float y) {
-        this(name, hp, sprite);
+    protected Entity(String name, Sprite sprite, float x, float y) {
+        this(name, sprite);
 
         setPosition(x, y);
-    }
-
-    private float getBarX() {
-        return sprite.getX() + sprite.getWidth() / 2 - barWidth / 2;
-    }
-
-    private float getBarY() {
-        return sprite.getY() + sprite.getHeight();
     }
 
     /**
@@ -148,18 +129,6 @@ public abstract class Entity {
      */
     public String getName() {
         return name;
-    }
-
-    public int getHP() {
-        return hp;
-    }
-
-    public void setHP(int hp) {
-        this.hp = hp;
-    }
-
-    public void changeHP(int change) {
-        setHP(hp + change);
     }
 
     /**
@@ -273,12 +242,6 @@ public abstract class Entity {
      */
     public void draw(SpriteBatch batch) {
         sprite.draw(batch);
-        if (displayBar) {
-            bar.x = getBarX();
-            bar.y = getBarY();
-            bar.update();
-            bar.draw(batch);
-        }
     }
 
     /**

--- a/core/src/com/infolk/game/combat/EntityObject.java
+++ b/core/src/com/infolk/game/combat/EntityObject.java
@@ -1,0 +1,13 @@
+package com.infolk.game.combat;
+
+import com.badlogic.gdx.graphics.g2d.Sprite;
+
+public class EntityObject extends Entity {
+    public EntityObject(String name, Sprite sprite) {
+        super(name, sprite);
+    }
+
+    public EntityObject(String name, Sprite sprite, float x, float y) {
+        super(name, sprite, x, y);
+    }
+}

--- a/core/src/com/infolk/game/combat/MortalBeing.java
+++ b/core/src/com/infolk/game/combat/MortalBeing.java
@@ -1,0 +1,62 @@
+package com.infolk.game.combat;
+
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.infolk.game.screens.components.HealthBar;
+
+public class MortalBeing extends Entity {
+    private int hp;
+
+    private HealthBar bar;
+    private float barWidth, barHeight;
+    public boolean displayBar = true;
+
+    public MortalBeing(String name, int hp, Sprite sprite) {
+        super(name, sprite);
+
+        this.hp = hp;
+
+        barWidth = getSprite().getWidth();
+        barHeight = barWidth / 5;
+
+        bar = new HealthBar(getBarX(), getBarY(), barWidth, barHeight, hp, hp);
+    }
+
+    public MortalBeing(String name, int hp, Sprite sprite, float x, float y) {
+        this(name, hp, sprite);
+        setPosition(x, y);
+
+        this.hp = hp;
+    }
+
+    private float getBarX() {
+        return getSprite().getX() + getSprite().getWidth() / 2 - barWidth / 2;
+    }
+
+    private float getBarY() {
+        return getSprite().getY() + getSprite().getHeight();
+    }
+
+    public void draw(SpriteBatch batch) {
+        super.draw(batch);
+        
+        if (displayBar) {
+            bar.x = getBarX();
+            bar.y = getBarY();
+            bar.update();
+            bar.draw(batch);
+        }
+    }
+
+    public int getHP() {
+        return hp;
+    }
+
+    public void setHP(int hp) {
+        this.hp = hp;
+    }
+
+    public void changeHP(int change) {
+        setHP(hp + change);
+    }
+}

--- a/core/src/com/infolk/game/combat/NPC.java
+++ b/core/src/com/infolk/game/combat/NPC.java
@@ -2,7 +2,7 @@ package com.infolk.game.combat;
 
 import com.badlogic.gdx.graphics.g2d.Sprite;
 
-public class NPC extends Entity {
+public class NPC extends MortalBeing {
     public NPC(String name, int hp, Sprite sprite, float x, float y) {
         super(name, hp, sprite, x, y);
     }

--- a/core/src/com/infolk/game/combat/Playable.java
+++ b/core/src/com/infolk/game/combat/Playable.java
@@ -2,7 +2,7 @@ package com.infolk.game.combat;
 
 import com.badlogic.gdx.graphics.g2d.Sprite;
 
-public class Playable extends Entity {
+public class Playable extends MortalBeing {
     private int dashFactor;
     private float energy;
 

--- a/core/src/com/infolk/game/screens/GameScreen.java
+++ b/core/src/com/infolk/game/screens/GameScreen.java
@@ -12,6 +12,9 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.infolk.game.App;
 import com.infolk.game.App.ScreenState;
+import com.infolk.game.combat.Entity;
+import com.infolk.game.combat.EntityObject;
+import com.infolk.game.combat.EntityObject;
 import com.infolk.game.combat.NPC;
 import com.infolk.game.combat.Playable;
 import com.infolk.game.core.GameManager;
@@ -79,7 +82,7 @@ public class GameScreen extends DefaultScreen implements MapChangeListener {
 		Playable player = new Playable("Player", 10, new Sprite(playerSprite));
 
 		Sprite obstacleSprite = new Sprite(new Texture(Gdx.files.internal("sprites/badlogic.jpg")));
-		NPC obstacle = new NPC("obst", 10, obstacleSprite, 0, 0);
+		EntityObject obstacle = new EntityObject("obst", obstacleSprite, 0, 0);
 		obstacle.setPosition(300, 200);
 
 		mapController.addPlayer(player);


### PR DESCRIPTION
Entities no longer have HP or the health bar associated with them (as it might not make a whole lot of sense to have this for simple objects, which use Entity, too). Instead, this functionality can now be found in MortalBeing, which NPC and Playable now extend.